### PR TITLE
Fix day backgrounf color when PickerType is JNormal

### DIFF
--- a/lib/_src/_jWidgets.dart
+++ b/lib/_src/_jWidgets.dart
@@ -280,18 +280,23 @@ class JGlobalDatePicker extends StatelessWidget {
                                               fDate: dateTime.dateTime))),
                             ),
                           if (pickerType == PickerType.JNormal)
-                            CalendarDatePicker(
-                              initialDate: checkDate(selectedDate),
-                              firstDate: checkDate(startDate),
-                              lastDate: checkDate(endDate),
-                              initialCalendarMode:
-                                  pickerMode ?? DatePickerMode.day,
-                              selectableDayPredicate: selectableDayPredicate,
-                              onDateChanged: onChange != null
-                                  ? (dateTime) => onChange!(JPickerValue.value(
-                                      JDateModel(dateTime: dateTime)))
-                                  : (dateTime) => selected = JPickerValue.value(
-                                      JDateModel(dateTime: dateTime)),
+                            Material(
+                              type: MaterialType.transparency,
+                              child: CalendarDatePicker(
+                                initialDate: checkDate(selectedDate),
+                                firstDate: checkDate(startDate),
+                                lastDate: checkDate(endDate),
+                                initialCalendarMode:
+                                    pickerMode ?? DatePickerMode.day,
+                                selectableDayPredicate: selectableDayPredicate,
+                                onDateChanged: onChange != null
+                                    ? (dateTime) => onChange!(
+                                        JPickerValue.value(
+                                            JDateModel(dateTime: dateTime)))
+                                    : (dateTime) => selected =
+                                        JPickerValue.value(
+                                            JDateModel(dateTime: dateTime)),
+                              ),
                             ),
                         ],
                       ),


### PR DESCRIPTION
## Problem
Theme properties (especially `dayBackgroundColor`) weren't propagating correctly in `JNormal` mode due to missing Material ancestor.

## Solution
Wrapped `CalendarDatePicker` with `Material(type: MaterialType.transparency)` to:
- Allow proper theme inheritance
- Fix day selection highlighting
- Maintain existing behavior